### PR TITLE
Modified makefile to run yarn once, and check if tree-sitter is on path. Also added a little to the readme.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+SHELL:=/bin/bash
+
 TREE_SITTER=tree-sitter
 
-all: fmt gen test
+all: binp depsp fmt gen test
 
 fmt:
 	./node_modules/.bin/prettier --write grammar.js
@@ -16,6 +18,10 @@ debug: gen
 .PHONY: gen
 gen:
 	$(TREE_SITTER) generate
+
+.PHONY: depsp
+depsp:
+	@if [ ! -d "node_modules" ]; then $(MAKE) deps; fi
 
 .PHONY: deps
 deps:
@@ -33,3 +39,6 @@ wasm:
 publish: all wasm
 	cp ./tree-sitter-erlang.wasm ./docs
 
+.PHONY: binp
+binp:
+	@if [ ! -x "`command -v $(TREE_SITTER)`" ]; then echo 'Error: tree-sitter cannot be found on your path.' >&2; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # tree-sitter grammar for Erlang
 
 Installation:
-1). Install `tree-sitter` from [the tree-sitter release page](https://github.com/tree-sitter/tree-sitter/releases)
-1). Run `make` in the `tree-sitter-erlang` directory. This should automatically
-install dependencies via yarn and run all tests.
+1. Install `tree-sitter` from [the tree-sitter release page](https://github.com/tree-sitter/tree-sitter/releases)
+1. Run `make` in the `tree-sitter-erlang` directory. This should automatically
+install dependencies via `yarn` and run all tests.
 
 Based on the [Standard Erlang grammar shipped with
 OTP](https://github.com/erlang/otp/blob/master/lib/stdlib/src/erl_parse.yrl).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # tree-sitter grammar for Erlang
 
+Installation:
+1). Install `tree-sitter` from [the tree-sitter release page](https://github.com/tree-sitter/tree-sitter/releases)
+1). Run `make` in the `tree-sitter-erlang` directory. This should automatically
+install dependencies via yarn and run all tests.
+
 Based on the [Standard Erlang grammar shipped with
 OTP](https://github.com/erlang/otp/blob/master/lib/stdlib/src/erl_parse.yrl).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # tree-sitter grammar for Erlang
 
 Installation:
-1. Install `tree-sitter` from [the tree-sitter release page](https://github.com/tree-sitter/tree-sitter/releases)
+1. Download `tree-sitter` from [the tree-sitter release
+   page](https://github.com/tree-sitter/tree-sitter/releases) and place it
+   somewhere on your path.
 1. Run `make` in the `tree-sitter-erlang` directory. This should automatically
 install dependencies via `yarn` and run all tests.
 


### PR DESCRIPTION
It is still unclear to me what this project is supposed to do. It was odd to me that `tree-sitter` was not something I could install via cargo, and that I had to install it from their github release page.

I really want to add to the readme, so that it would be clearer what people could be doing to help. Adding test cases? Making it faster?

I fixed the Makefile so that now it calls deps only once if node_modules doesn't exist, and also checks if tree-sitter is on the path before executing it. Sorry for the bad formatting of the bash code within the Makefile, I couldn't figure out how to make it multi-line.