### PR TITLE
fix: Parser hanging

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -110,7 +110,7 @@ module.exports = grammar({
 
   word: ($) => $._unquoted_atom,
 
-  extras: ($) => [/[\x00-\x20\x80-\xA0]/, $.comment],
+  extras: ($) => [/[\x01-\x20\x80-\xA0]/, $.comment],
 
   inline: ($) => [$.term, $.expression],
 
@@ -166,7 +166,7 @@ module.exports = grammar({
     function_clause: ($) =>
       prec(PREC.FUNCTION_CLAUSE, seq(field("name", $.atom), $.lambda_clause)),
 
-    comment: ($) => /%.*\n/,
+    comment: ($) => /%.*/,
 
     ////////////////////////////////////////////////////////////////////////////
     //


### PR DESCRIPTION
This PR fixes several issues: https://github.com/tree-sitter/tree-sitter/issues/1311 and #2 #9.
The root cause of the issue was that the `\x00` byte shouldn't be used in regexps and especially in the extras, but tree-sitter seems currently doesn't have a fuse against this on its parser generation phase.

Also I'm sure that it's better to have comment tokens that don't occupy more then a one line range so I've removed `\n` from its definition too. The `.` in tree-sitters regular expressions doesn't include `\n` bytes so it's enough to have the `comment` rule defined as `/%.*/`.